### PR TITLE
Enable phone dictation via SignalR

### DIFF
--- a/fronts/host/src/App.jsx
+++ b/fronts/host/src/App.jsx
@@ -11,6 +11,8 @@ export default function App() {
   const [notification, setNotification] = useState(false);
   const [activeTab, setActiveTab] = useState('admision');
   const [versionesRecibidas, setVersionesRecibidas] = useState(null);
+  const [dictationText, setDictationText] = useState('');
+  const [showDictationModal, setShowDictationModal] = useState(false);
 
   const load = async (ver) => {
     if (ver === '') {
@@ -84,6 +86,11 @@ export default function App() {
         .catch(error => console.error(error));
       setNotification(true);
     })
+
+    connection.on('ReceiveDictation', (text) => {
+      setDictationText(text);
+    })
+
     connection.start().catch(err => console.error(err))
   }, []);
 
@@ -111,9 +118,14 @@ export default function App() {
     padding: '20px 0'
   };
 
+  const mobileUrl = `http://${window.location.hostname}:5018/dictation.html`;
+
   return (
     <main style={{ fontFamily: 'sans-serif' }}>
       <h1>POC Federación Versionada</h1>
+      <button onClick={() => setShowDictationModal(true)}>
+        Conectar teléfono
+      </button>
 
       <div style={tabStyle}>
         <button
@@ -212,6 +224,26 @@ export default function App() {
             >
               Cargar nueva
             </button>
+          </div>
+        </div>
+      )}
+
+      {showDictationModal && (
+        <div style={{
+          position: 'fixed', top: 0, left: 0, right: 0, bottom: 0,
+          backgroundColor: 'rgba(0,0,0,0.5)', display: 'flex',
+          alignItems: 'center', justifyContent: 'center', zIndex: 2000
+        }}>
+          <div style={{ background: 'white', padding: 20, borderRadius: 8, width: '300px' }}>
+            <h3>Dictado desde teléfono</h3>
+            <p>Abre <a href={mobileUrl} target="_blank" rel="noreferrer">{mobileUrl}</a> en tu teléfono.</p>
+            <textarea readOnly value={dictationText} style={{ width: '100%', height: '80px' }} />
+            <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: 10 }}>
+              <button onClick={() => navigator.clipboard.writeText(dictationText)}>
+                📋 Copiar
+              </button>
+              <button onClick={() => setShowDictationModal(false)}>Cerrar</button>
+            </div>
           </div>
         </div>
       )}

--- a/version-backend/SignalRWebpack/Hubs/ChatHub.cs
+++ b/version-backend/SignalRWebpack/Hubs/ChatHub.cs
@@ -4,5 +4,9 @@ namespace SignalRWebpack.Hubs
 {
     public class ChatHub : Hub
     {
+        public async Task SendDictation(string text)
+        {
+            await Clients.All.SendAsync("ReceiveDictation", text);
+        }
     }
 }

--- a/version-backend/SignalRWebpack/wwwroot/dictation.html
+++ b/version-backend/SignalRWebpack/wwwroot/dictation.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Phone Dictation</title>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/microsoft-signalr/8.0.7/signalr.min.js"></script>
+  <style>
+    body { font-family: sans-serif; padding: 20px; }
+    textarea { width: 100%; height: 120px; margin-top: 10px; }
+  </style>
+</head>
+<body>
+  <h1>Dictar texto</h1>
+  <button id="start">Iniciar</button>
+  <button id="stop">Detener</button>
+  <textarea id="text"></textarea>
+<script>
+  const connection = new signalR.HubConnectionBuilder().withUrl('/hub').build();
+  connection.start().catch(err => console.error(err));
+  const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
+  const recognizer = new SpeechRecognition();
+  recognizer.lang = 'es-ES';
+  recognizer.continuous = true;
+  recognizer.interimResults = false;
+  recognizer.onresult = ev => {
+    const txt = Array.from(ev.results).map(r => r[0].transcript).join(' ');
+    document.getElementById('text').value = txt;
+    connection.invoke('SendDictation', txt);
+  };
+  document.getElementById('start').onclick = () => recognizer.start();
+  document.getElementById('stop').onclick = () => recognizer.stop();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- serve a small dictation page from the backend that uses Web Speech API
- broadcast text from a new `SendDictation` hub method
- add button and modal in the host app for connecting a phone and viewing transcribed text

## Testing
- `dotnet build` *(fails: command not found)*
- `npm run build` in `fronts/host` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d1623f66c8320a37fa0d57e437f1d